### PR TITLE
Fixed skipping of first answer atom in RightFinalAnswer game stage.

### DIFF
--- a/src/Common/SIEngine/TvEngine.cs
+++ b/src/Common/SIEngine/TvEngine.cs
@@ -271,7 +271,6 @@ namespace SIEngine
                     }
                     else
                     {
-                        _atomIndex++;
                         PlayQuestionAtom();
                         Stage = GameStage.RightAnswerProceed;
                         AutoNext(3000);


### PR DESCRIPTION
Во время игры была обнаружена проблема: в **финальном** раунде при наличии составного ответа первый `atom` ответа любого типа пропускается.
<details><summary><b>Пример:</b></summary>

Конкретно здесь `Ответ 1.` будет пропущен при показе финального ответа.  

<img width="367" alt="image" src="https://user-images.githubusercontent.com/64899574/166169372-1171f3d0-90fe-4d49-9f8f-c52d3075f198.png">
</details>

При этом составные ответы в обычных раундах работает как задумано.
Данный PR исправляет данную проблему и не затрагивает остальную логику работы правильных ответов.

<details><summary>.</summary>


![Levid zahotel.](https://user-images.githubusercontent.com/64899574/166170243-4beebc34-7491-4cde-a5c5-034dfb2519b0.png)
</details>