### PR TITLE
Доработка тёмной темы и добавление тёмно-серой темы

### DIFF
--- a/src/SIQuester/SIQuester.ViewModel/Model/Enums.cs
+++ b/src/SIQuester/SIQuester.ViewModel/Model/Enums.cs
@@ -88,5 +88,7 @@ public enum ThemeOption
     [Description("ThemeOptionLight")]
     Light,
     [Description("ThemeOptionDark")]
-    Dark
+    Dark,
+    [Description("ThemeOptionDarkGray")]
+    DarkGray
 }

--- a/src/SIQuester/SIQuester/App.xaml
+++ b/src/SIQuester/SIQuester/App.xaml
@@ -42,7 +42,8 @@
             <siqcv:ThemeToBrushConverter
                 x:Key="ThemeBackgroundConverter"
                 LightBrush="#FFFBFBFF"
-                DarkBrush="Black" />
+                DarkBrush="Black"
+                DarkGrayBrush="#FF1E1E1E" />
             <siqcv:ThemeToBrushConverter
                 x:Key="ThemeForegroundConverter"
                 LightBrush="Black"
@@ -59,6 +60,11 @@
                 x:Key="ToolBarHoverBorderColorConverter"
                 LightColor="#990000FF"
                 DarkColor="#FF6A6A6A" />
+            <siqcv:ThemeToColorConverter
+                x:Key="ToolBarCheckedColorConverter"
+                LightColor="#E6F0FA"
+                DarkColor="#FF4A4A4A"
+                DarkGrayColor="#FF2E4550" />
             <siqcv:ThemeToColorConverter
                 x:Key="ItemOverColorConverter"
                 LightColor="#FFE9E9FF"
@@ -78,7 +84,78 @@
             <siqcv:ThemeToColorConverter
                 x:Key="SimpleAnswerBackgroundConverter"
                 LightColor="Honeydew"
+                DarkColor="#FF2A2A2A"
+                DarkGrayColor="#FF253325" />
+            <siqcv:ThemeToColorConverter
+                x:Key="MainBackColorConverter"
+                LightColor="#FFFBFBFF"
+                DarkColor="Black"
+                DarkGrayColor="#FF1E1E1E" />
+            <siqcv:ThemeToColorConverter
+                x:Key="LavenderColorConverter"
+                LightColor="Lavender"
+                DarkColor="#FF262626"
+                DarkGrayColor="#FF2A2D3A" />
+            <siqcv:ThemeToColorConverter
+                x:Key="SidePanelColorConverter"
+                LightColor="Lavender"
+                DarkColor="Black"
+                DarkGrayColor="#FF1E1E1E" />
+            <siqcv:ThemeToColorConverter
+                x:Key="LightBlueColorConverter"
+                LightColor="LightBlue"
+                DarkColor="#FF2D2D2D"
+                DarkGrayColor="#FF1F3640" />
+            <siqcv:ThemeToColorConverter
+                x:Key="LightGrayColorConverter"
+                LightColor="LightGray"
                 DarkColor="#FF2A2A2A" />
+            <siqcv:ThemeToColorConverter
+                x:Key="WhiteColorConverter"
+                LightColor="White"
+                DarkColor="#FF252525" />
+            <siqcv:ThemeToColorConverter
+                x:Key="SectionHeaderColorConverter"
+                LightColor="#FFD2DCFF"
+                DarkColor="#FF2D2D2D"
+                DarkGrayColor="#FF2D3548" />
+            <siqcv:ThemeToColorConverter
+                x:Key="DarkRedTextColorConverter"
+                LightColor="DarkRed"
+                DarkColor="#FFFF8080" />
+            <siqcv:ThemeToColorConverter
+                x:Key="DarkBlueTextColorConverter"
+                LightColor="DarkBlue"
+                DarkColor="#FF8AB4FF" />
+            <siqcv:ThemeToColorConverter
+                x:Key="DarkGreenTextColorConverter"
+                LightColor="DarkGreen"
+                DarkColor="#FF7FD27F" />
+            <siqcv:ThemeToColorConverter
+                x:Key="DarkCyanTextColorConverter"
+                LightColor="DarkCyan"
+                DarkColor="#FF80DADA" />
+            <siqcv:ThemeToColorConverter
+                x:Key="TextBoxBorderColorConverter"
+                LightColor="#FFABAdB3"
+                DarkColor="#FF5A5A5A" />
+            <siqcv:ThemeToColorConverter
+                x:Key="TextBoxBackgroundColorConverter"
+                LightColor="#00FFFFFF"
+                DarkColor="#FF2A2A2A" />
+            <siqcv:ThemeToColorConverter
+                x:Key="WrongAnswerBackgroundColorConverter"
+                LightColor="#FFFFE1E6"
+                DarkColor="#FF2D2024" />
+            <siqcv:ThemeToColorConverter
+                x:Key="DurationBadgeColorConverter"
+                LightColor="#DDDDDD"
+                DarkColor="#FF3A3A3A" />
+            <siqcv:ThemeToColorConverter
+                x:Key="ActiveBrushColorConverter"
+                LightColor="#FFC5EFF3"
+                DarkColor="#FF3A3A3A"
+                DarkGrayColor="#FF2E4550" />
 
             <SolidColorBrush
                 x:Key="{x:Static SystemColors.ControlTextBrushKey}"
@@ -127,7 +204,48 @@
                 <x:Static Member="vmp:Resources.Link" />
             </util:StringList>
 
-            <SolidColorBrush x:Key="MainBack" Color="#FFFBFBFF" />
+            <SolidColorBrush
+                x:Key="MainBack"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource MainBackColorConverter}, FallbackValue=#FFFBFBFF, TargetNullValue=#FFFBFBFF}" />
+            <SolidColorBrush
+                x:Key="LavenderBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource LavenderColorConverter}, FallbackValue=Lavender, TargetNullValue=Lavender}" />
+            <SolidColorBrush
+                x:Key="SidePanelBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource SidePanelColorConverter}, FallbackValue=Lavender, TargetNullValue=Lavender}" />
+            <SolidColorBrush
+                x:Key="LightBlueBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource LightBlueColorConverter}, FallbackValue=LightBlue, TargetNullValue=LightBlue}" />
+            <SolidColorBrush
+                x:Key="LightGrayBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource LightGrayColorConverter}, FallbackValue=LightGray, TargetNullValue=LightGray}" />
+            <SolidColorBrush
+                x:Key="WhiteBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource WhiteColorConverter}, FallbackValue=White, TargetNullValue=White}" />
+            <SolidColorBrush
+                x:Key="SectionHeaderBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource SectionHeaderColorConverter}, FallbackValue=#FFD2DCFF, TargetNullValue=#FFD2DCFF}" />
+            <SolidColorBrush
+                x:Key="DarkRedTextBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource DarkRedTextColorConverter}, FallbackValue=DarkRed, TargetNullValue=DarkRed}" />
+            <SolidColorBrush
+                x:Key="DarkBlueTextBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource DarkBlueTextColorConverter}, FallbackValue=DarkBlue, TargetNullValue=DarkBlue}" />
+            <SolidColorBrush
+                x:Key="DarkGreenTextBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource DarkGreenTextColorConverter}, FallbackValue=DarkGreen, TargetNullValue=DarkGreen}" />
+            <SolidColorBrush
+                x:Key="DarkCyanTextBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource DarkCyanTextColorConverter}, FallbackValue=DarkCyan, TargetNullValue=DarkCyan}" />
+            <SolidColorBrush
+                x:Key="WrongAnswerBackgroundBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource WrongAnswerBackgroundColorConverter}, FallbackValue=#FFFFE1E6, TargetNullValue=#FFFFE1E6}" />
+            <SolidColorBrush
+                x:Key="DurationBadgeBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource DurationBadgeColorConverter}, FallbackValue=#DDDDDD, TargetNullValue=#DDDDDD}" />
+            <SolidColorBrush
+                x:Key="ActiveBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource ActiveBrushColorConverter}, FallbackValue=#FFC5EFF3, TargetNullValue=#FFC5EFF3}" />
 
             <m:QuestionTypesNamesNew x:Key="QTypesNew" />
 
@@ -144,13 +262,18 @@
                     Grid.Row="0" />
             </ControlTemplate>
 
-            <SolidColorBrush x:Key="TextBox.Static.Border" Color="#FFABAdB3"/>
+            <SolidColorBrush
+                x:Key="TextBox.Static.Border"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource TextBoxBorderColorConverter}, FallbackValue=#FFABAdB3, TargetNullValue=#FFABAdB3}" />
             <SolidColorBrush x:Key="TextBox.MouseOver.Border" Color="#FF7EB4EA"/>
             <SolidColorBrush x:Key="TextBox.Focus.Border" Color="#FF569DE5"/>
+            <SolidColorBrush
+                x:Key="TextBoxBackgroundBrush"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource TextBoxBackgroundColorConverter}, FallbackValue=#00FFFFFF, TargetNullValue=#00FFFFFF}" />
 
             <Style x:Key="CommonTextBox" TargetType="{x:Type TextBox}">
                 <Setter Property="BorderThickness" Value="0" />
-                <Setter Property="Background" Value="Transparent" />
+                <Setter Property="Background" Value="{StaticResource TextBoxBackgroundBrush}" />
                 <Setter Property="TextWrapping" Value="Wrap" />
                 <Setter Property="Height" Value="Auto" />
                 <Setter Property="SpellCheck.IsEnabled" Value="{Binding SpellChecking, Source={x:Static m:AppSettings.Default}}" />
@@ -590,7 +713,9 @@
                 Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource ToolBarHoverColorConverter}, FallbackValue=#330000FF, TargetNullValue=#330000FF}" />
             <SolidColorBrush x:Key="ToolBarButtonPressedBorder" Color="#FF0000FF"/>
             <SolidColorBrush x:Key="ToolBarButtonPressed" Color="#770000FF"/>
-            <SolidColorBrush x:Key="ToolBarButtonChecked" Color="#E6F0FA"/>
+            <SolidColorBrush
+                x:Key="ToolBarButtonChecked"
+                Color="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource ToolBarCheckedColorConverter}, FallbackValue=#E6F0FA, TargetNullValue=#E6F0FA}" />
 
             <Style x:Key="{x:Static ToolBar.ToggleButtonStyleKey}" TargetType="{x:Type ToggleButton}">
                 <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"/>
@@ -1109,24 +1234,88 @@
                                                 </Setter>
                                             </Style>
 
-                                            <Style x:Key="SubMenuItemQuestionType" TargetType="MenuItem">
+                                            <Style x:Key="SubMenuTypeItem" TargetType="MenuItem">
+                                                <Setter Property="Padding" Value="5" />
+                                                <!-- Render this menu with the light look in every theme (MahApps dark menus hurt readability here). -->
+                                                <Setter Property="Background" Value="#FFF5F5F5" />
+                                                <Setter Property="Foreground" Value="#FF1E1E1E" />
+
+                                                <Setter Property="Template">
+                                                    <Setter.Value>
+                                                        <ControlTemplate TargetType="MenuItem">
+                                                            <Border x:Name="Bd" Background="{TemplateBinding Background}" SnapsToDevicePixels="True">
+                                                                <Grid>
+                                                                    <Grid.ColumnDefinitions>
+                                                                        <ColumnDefinition Width="20" />
+                                                                        <ColumnDefinition Width="*" />
+                                                                    </Grid.ColumnDefinitions>
+
+                                                                    <Rectangle
+                                                                        x:Name="HoverBg"
+                                                                        Grid.ColumnSpan="2"
+                                                                        Fill="{StaticResource MenuItemSelectionFill}"
+                                                                        Visibility="Collapsed" />
+
+                                                                    <Path
+                                                                        x:Name="Check"
+                                                                        Grid.Column="0"
+                                                                        Width="11"
+                                                                        Height="11"
+                                                                        HorizontalAlignment="Center"
+                                                                        VerticalAlignment="Center"
+                                                                        Stretch="Uniform"
+                                                                        Visibility="Collapsed"
+                                                                        Stroke="{TemplateBinding Foreground}"
+                                                                        StrokeThickness="1.5"
+                                                                        StrokeStartLineCap="Round"
+                                                                        StrokeEndLineCap="Round"
+                                                                        StrokeLineJoin="Round"
+                                                                        Data="M1,5 L4,8 L9,1" />
+
+                                                                    <ContentPresenter
+                                                                        Grid.Column="1"
+                                                                        Margin="{TemplateBinding Padding}"
+                                                                        ContentSource="Header"
+                                                                        VerticalAlignment="Center"
+                                                                        RecognizesAccessKey="True"
+                                                                        SnapsToDevicePixels="{TemplateBinding SnapsToDevicePixels}" />
+                                                                </Grid>
+                                                            </Border>
+
+                                                            <ControlTemplate.Triggers>
+                                                                <Trigger Property="IsHighlighted" Value="True">
+                                                                    <Setter TargetName="HoverBg" Property="Visibility" Value="Visible" />
+                                                                </Trigger>
+
+                                                                <Trigger Property="IsChecked" Value="True">
+                                                                    <Setter TargetName="Check" Property="Visibility" Value="Visible" />
+                                                                </Trigger>
+
+                                                                <Trigger Property="IsEnabled" Value="False">
+                                                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.GrayTextBrushKey}}" />
+                                                                </Trigger>
+                                                            </ControlTemplate.Triggers>
+                                                        </ControlTemplate>
+                                                    </Setter.Value>
+                                                </Setter>
+                                            </Style>
+
+                                            <Style x:Key="SubMenuItemQuestionType" TargetType="MenuItem" BasedOn="{StaticResource SubMenuTypeItem}">
                                                 <Setter
                                                     Property="Command"
                                                     Value="{Binding DataContext.SetQuestionType, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType=Menu}}" />
 
                                                 <Setter Property="CommandParameter" Value="{Binding Key}" />
                                                 <Setter Property="Header" Value="{Binding Value}" />
-                                                <Setter Property="Padding" Value="5" />
                                             </Style>
 
-                                            <Style x:Key="SubMenuItemAnswerType" TargetType="MenuItem">
+                                            <Style x:Key="SubMenuItemAnswerType" TargetType="MenuItem" BasedOn="{StaticResource SubMenuTypeItem}">
                                                 <Setter
                                                     Property="Command"
                                                     Value="{Binding DataContext.SetAnswerType, RelativeSource={RelativeSource Mode=FindAncestor, AncestorLevel=1, AncestorType=Menu}}" />
 
                                                 <Setter Property="CommandParameter" Value="{Binding Key}" />
                                                 <Setter Property="Header" Value="{Binding Value}" />
-                                                <Setter Property="Padding" Value="5" />
 
                                                 <Style.Triggers>
                                                     <DataTrigger Value="True">
@@ -2519,7 +2708,7 @@
                     Style="{StaticResource LightTextBox}"
                     CurrentPosition="{Binding CurrentPosition, Mode=OneWayToSource}"
                     ItemsSource="{Binding}"
-                    Background="#FFFFE1E6"
+                    Background="{StaticResource WrongAnswerBackgroundBrush}"
                     siq:SmartMenuManager.SecondMenu="True"
                     siq:ActivateManager.IsWatching="True"
                     Padding="4" />
@@ -2542,7 +2731,7 @@
             <siqcv:TimeSpanToSecondsConverter x:Key="TimeSpanToSecondsConverter" />
 
             <ControlTemplate TargetType="ContentControl" x:Key="ContentItemDurationTemplate">
-                <StackPanel Background="#DDDDDD" Margin="0,0,2,0" Orientation="Horizontal" ToolTip="{x:Static lp:Resources.Duration}">
+                <StackPanel Background="{StaticResource DurationBadgeBrush}" Margin="0,0,2,0" Orientation="Horizontal" ToolTip="{x:Static lp:Resources.Duration}">
                     <Image Source="{StaticResource AddTimeImage}" Width="10" Margin="4,0,0,0" />
                     
                     <siq:NumericTextBox
@@ -2627,7 +2816,7 @@
                                         <TextBox
                                             IsReadOnly="True"
                                             Style="{StaticResource CommonTextBox}"
-                                            Foreground="DarkRed"
+                                            Foreground="{StaticResource DarkRedTextBrush}"
                                             TextWrapping="Wrap"
                                             Height="Auto"
                                             MinWidth="50"
@@ -2674,7 +2863,7 @@
                                         <TextBox
                                             IsReadOnly="True"
                                             Style="{StaticResource CommonTextBox}"
-                                            Foreground="DarkBlue"
+                                            Foreground="{StaticResource DarkBlueTextBrush}"
                                             TextWrapping="Wrap"
                                             Height="Auto"
                                             MinWidth="50"
@@ -2732,7 +2921,7 @@
                                         <TextBox
                                             IsReadOnly="True"
                                             Style="{StaticResource CommonTextBox}"
-                                            Foreground="DarkGreen"
+                                            Foreground="{StaticResource DarkGreenTextBrush}"
                                             TextWrapping="Wrap"
                                             Height="Auto"
                                             MinWidth="50"
@@ -2757,7 +2946,7 @@
                                 <TextBox
                                     IsReadOnly="True"
                                     Style="{StaticResource CommonTextBox}"
-                                    Foreground="DarkCyan"
+                                    Foreground="{StaticResource DarkCyanTextBrush}"
                                     TextWrapping="Wrap"
                                     Height="Auto"
                                     MinWidth="50"
@@ -2975,13 +3164,13 @@
                         Margin="5,2,3,2" />
 
                     <Border
-                        Background="LightBlue"
+                        Background="{StaticResource LightBlueBrush}"
                         MinWidth="25"
                         Margin="1">
                         <ContentControl
                             x:Name="value"
                             Margin="0,2,0,0"
-                            TextBlock.Foreground="Black"
+                            TextBlock.Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                             Content="{Binding Value}"
                             ContentTemplate="{Binding Value.Model.Type, Converter={StaticResource GroupParameterSelector}}"
                             KeyboardNavigation.IsTabStop="False" />
@@ -3066,7 +3255,7 @@
                         <TextBlock
                             Text="{Binding}"
                             FontWeight="Bold"
-                            Foreground="Black" />
+                            Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
                     </DataTemplate>
                 </siqcv:TemplateConverter.DefaultTemplate>
 
@@ -3077,7 +3266,7 @@
                                 DockPanel.Dock="Left"
                                 Text="{Binding}"
                                 FontWeight="Bold"
-                                Foreground="Black"
+                                Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                 Margin="0,3,0,0" />
                             
                             <Button
@@ -3116,7 +3305,7 @@
                                 <ContentControl
                                     x:Name="value"
                                     Margin="0,2,0,0"
-                                    TextBlock.Foreground="Black"
+                                    TextBlock.Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                     Content="{Binding Value}"
                                     ContentTemplate="{Binding Value.Model.Type, Converter={StaticResource ParameterSelector}}"
                                     KeyboardNavigation.IsTabStop="False" />
@@ -3231,7 +3420,7 @@
 
                     <TextBlock
                         Text="{x:Static lp:Resources.Deviation}"
-                        Foreground="Black"
+                        Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                         FontSize="18"
                         Margin="8,1,3,0" />
 
@@ -3241,7 +3430,7 @@
                         MinWidth="75"
                         Padding="3"
                         Margin="5,0,0,0"
-                        Background="#F3F3F3"
+                        Background="{StaticResource SimpleAnswerBackgroundBrush}"
                         ToolTip="{x:Static lp:Resources.AnswerDeviation}" />
                 </StackPanel>
             </DataTemplate>
@@ -3265,7 +3454,7 @@
             </DataTemplate>
 
             <ControlTemplate TargetType="ContentControl" x:Key="AnswerDurationTemplate">
-                <StackPanel Background="#DDDDDD" Margin="0,0,5,0" Orientation="Horizontal" ToolTip="{x:Static lp:Resources.AnswerDuration}" VerticalAlignment="Center">
+                <StackPanel Background="{StaticResource DurationBadgeBrush}" Margin="0,0,5,0" Orientation="Horizontal" ToolTip="{x:Static lp:Resources.AnswerDuration}" VerticalAlignment="Center">
                     <Image Source="{StaticResource AddTimeImage}" Width="10" Margin="4,0,0,0" />
 
                     <siq:NumericTextBox

--- a/src/SIQuester/SIQuester/App.xaml.cs
+++ b/src/SIQuester/SIQuester/App.xaml.cs
@@ -195,7 +195,7 @@ public partial class App : Application
 
     private void UpdateTheme()
     {
-        var themeUri = _settings.Theme == ThemeOption.Dark ? DarkBlueThemeUri : LightBlueThemeUri;
+        var themeUri = _settings.Theme == ThemeOption.Light ? LightBlueThemeUri : DarkBlueThemeUri;
         var dictionaries = Resources.MergedDictionaries;
 
         var themeDictionary = dictionaries.FirstOrDefault(

--- a/src/SIQuester/SIQuester/Converters/ThemeToBrushConverter.cs
+++ b/src/SIQuester/SIQuester/Converters/ThemeToBrushConverter.cs
@@ -11,11 +11,18 @@ public sealed class ThemeToBrushConverter : IValueConverter
     public Brush? LightBrush { get; set; }
     public Brush? DarkBrush { get; set; }
 
+    public Brush? DarkGrayBrush { get; set; }
+
     public object? Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is ThemeOption theme)
         {
-            return theme == ThemeOption.Dark ? DarkBrush ?? Brushes.Black : LightBrush ?? Brushes.White;
+            return theme switch
+            {
+                ThemeOption.Dark => DarkBrush ?? Brushes.Black,
+                ThemeOption.DarkGray => DarkGrayBrush ?? DarkBrush ?? Brushes.Black,
+                _ => LightBrush ?? Brushes.White,
+            };
         }
 
         return LightBrush ?? Brushes.White;

--- a/src/SIQuester/SIQuester/Converters/ThemeToColorConverter.cs
+++ b/src/SIQuester/SIQuester/Converters/ThemeToColorConverter.cs
@@ -11,11 +11,18 @@ public sealed class ThemeToColorConverter : IValueConverter
     public Color LightColor { get; set; }
     public Color DarkColor { get; set; }
 
+    public Color? DarkGrayColor { get; set; }
+
     public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
     {
         if (value is ThemeOption theme)
         {
-            return theme == ThemeOption.Dark ? DarkColor : LightColor;
+            return theme switch
+            {
+                ThemeOption.Dark => DarkColor,
+                ThemeOption.DarkGray => DarkGrayColor ?? DarkColor,
+                _ => LightColor,
+            };
         }
 
         return LightColor;

--- a/src/SIQuester/SIQuester/Properties/Resources.resx
+++ b/src/SIQuester/SIQuester/Properties/Resources.resx
@@ -1221,6 +1221,9 @@ When there are some questions in theme, they will be used as examples</value>
   <data name="ThemeOptionDark" xml:space="preserve">
     <value>Dark</value>
   </data>
+  <data name="ThemeOptionDarkGray" xml:space="preserve">
+    <value>Dark gray</value>
+  </data>
   <data name="ThemeOptionLight" xml:space="preserve">
     <value>Light</value>
   </data>

--- a/src/SIQuester/SIQuester/Properties/Resources.ru-RU.resx
+++ b/src/SIQuester/SIQuester/Properties/Resources.ru-RU.resx
@@ -1217,6 +1217,9 @@
   <data name="ThemeOptionDark" xml:space="preserve">
     <value>Тёмная</value>
   </data>
+  <data name="ThemeOptionDarkGray" xml:space="preserve">
+    <value>Тёмно-серая</value>
+  </data>
   <data name="ThemeOptionLight" xml:space="preserve">
     <value>Светлая</value>
   </data>

--- a/src/SIQuester/SIQuester/View/Dialogs/ExportToSteamView.xaml
+++ b/src/SIQuester/SIQuester/View/Dialogs/ExportToSteamView.xaml
@@ -43,7 +43,7 @@
             </ComboBox>
 
             <TextBlock Grid.Row="1" Text="{x:Static lp:Resources.Name}" VerticalAlignment="Center" />
-            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Title, Mode=OneWay}" IsReadOnly="True" Background="LightGray" Margin="10,10,0,0" Padding="2" />
+            <TextBox Grid.Row="1" Grid.Column="1" Text="{Binding Title, Mode=OneWay}" IsReadOnly="True" Background="{StaticResource LightGrayBrush}" Margin="10,10,0,0" Padding="2" />
             <TextBlock Grid.Row="2" Text="{x:Static lp:Resources.Description}" VerticalAlignment="Top" Margin="0,10,0,0" />
 
             <TextBox

--- a/src/SIQuester/SIQuester/View/Dialogs/SelectPointView.xaml
+++ b/src/SIQuester/SIQuester/View/Dialogs/SelectPointView.xaml
@@ -10,7 +10,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         
-        <Grid Name="ReferenceGrid" Background="LightGray" SizeChanged="ReferenceGrid_SizeChanged" ClipToBounds="True">
+        <Grid Name="ReferenceGrid" Background="{StaticResource LightGrayBrush}" SizeChanged="ReferenceGrid_SizeChanged" ClipToBounds="True">
             <Image Name="TargetImage" Stretch="Uniform" Opacity="0.6" />
             <Canvas Name="OverlayCanvas" IsHitTestVisible="False">
                 <Grid Name="SelectionMarker" Width="18" Height="18" Visibility="Hidden">

--- a/src/SIQuester/SIQuester/View/Dialogs/SendToGameDialog.xaml
+++ b/src/SIQuester/SIQuester/View/Dialogs/SendToGameDialog.xaml
@@ -24,6 +24,6 @@
             HorizontalAlignment="Left" />
         
         <Button Command="{Binding Send}" Margin="0,5,0,0" HorizontalAlignment="Left" Padding="10,5">Отправить</Button>
-        <TextBlock Foreground="DarkRed" Text="{Binding ErrorMessage}" Margin="0,5,0,0" />
+        <TextBlock Foreground="{StaticResource DarkRedTextBrush}" Text="{Binding ErrorMessage}" Margin="0,5,0,0" />
     </StackPanel>
 </UserControl>

--- a/src/SIQuester/SIQuester/View/Dictionaries/Controls.xaml
+++ b/src/SIQuester/SIQuester/View/Dictionaries/Controls.xaml
@@ -3,16 +3,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml">
     <SolidColorBrush x:Key="ActiveBrush" Color="#FFC5EFF3" />
 
-    <Style x:Key="ComboBoxCommon" TargetType="{x:Type ComboBox}">
-        <Setter Property="BorderThickness" Value="0" />
-        <Setter Property="Background" Value="Transparent" />
+    <Style x:Key="ComboBoxCommon" TargetType="{x:Type ComboBox}" BasedOn="{StaticResource {x:Type ComboBox}}">
         <Setter Property="Padding" Value="1" />
-        
-        <Style.Triggers>
-            <Trigger Property="IsMouseOver" Value="True">
-                <Setter Property="Background" Value="{StaticResource ActiveBrush}" />
-            </Trigger>
-        </Style.Triggers>
     </Style>
     
 </ResourceDictionary>

--- a/src/SIQuester/SIQuester/View/DocumentLoaderView.xaml
+++ b/src/SIQuester/SIQuester/View/DocumentLoaderView.xaml
@@ -19,7 +19,7 @@
                         <DataTemplate>
                             <TextBlock
                                 Text="{Binding ErrorMessage, Mode=OneWay}"
-                                Foreground="DarkRed"
+                                Foreground="{StaticResource DarkRedTextBrush}"
                                 VerticalAlignment="Center"
                                 HorizontalAlignment="Center" />
                         </DataTemplate>

--- a/src/SIQuester/SIQuester/View/DocumentView.xaml
+++ b/src/SIQuester/SIQuester/View/DocumentView.xaml
@@ -579,9 +579,9 @@
                             <Setter Property="ContentTemplate">
                                 <Setter.Value>
                                     <DataTemplate>
-                                        <Border Background="Lavender">
+                                        <Border Background="{StaticResource SidePanelBrush}">
                                             <Grid>
-                                                <TabControl BorderThickness="0,0,1,0" BorderBrush="LightGray" Margin="1,0,0,1" SelectedIndex="{Binding SideIndex}">
+                                                <TabControl BorderThickness="0,0,1,0" BorderBrush="{StaticResource LightGrayBrush}" Margin="1,0,0,1" SelectedIndex="{Binding SideIndex}">
                                                     <TabControl.Resources>
                                                         <Style TargetType="TabItem">
                                                             <Setter Property="Template">
@@ -637,7 +637,7 @@
                                                     
                                                     <TabControl.ContentTemplate>
                                                         <DataTemplate>
-                                                            <DockPanel>
+                                                            <DockPanel Background="{StaticResource SidePanelBrush}">
                                                                 <TextBlock
                                                                     Style="{StaticResource SideHeader}"
                                                                     Text="{Binding Header}"
@@ -791,7 +791,7 @@
             AllowsTransparency="True"
             PopupAnimation="Slide">
             <Border
-                Background="White"
+                Background="{StaticResource WhiteBrush}"
                 BorderBrush="#FFAEAEAE"
                 BorderThickness="1"
                 CornerRadius="3"
@@ -817,7 +817,7 @@
                             Foreground="#FF2060A0"
                             Margin="0,5,0,5" />
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static lp:Resources.RoundTypeStandard}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -828,7 +828,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,10">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,10">
                             <StackPanel>
                                 <TextBlock Text="{x:Static lp:Resources.RoundTypeFinal}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -847,7 +847,7 @@
                             Foreground="#FF2060A0"
                             Margin="0,5,0,5" />
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.SimpleQuestion}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -858,7 +858,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.StakeQuestion}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -869,7 +869,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.SecretQuestion}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -880,7 +880,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.SecretPublicPrice}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -891,7 +891,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.SecretNoQuestion}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -902,7 +902,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.NoRiskQuestion}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -913,7 +913,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.QuestionForAll}" FontWeight="SemiBold" />
                                 <TextBlock
@@ -924,7 +924,7 @@
                             </StackPanel>
                         </Border>
                         
-                        <Border Background="#FFF5F5F5" CornerRadius="3" Padding="8" Margin="0,0,0,5">
+                        <Border Background="{StaticResource WhiteBrush}" CornerRadius="3" Padding="8" Margin="0,0,0,5">
                             <StackPanel>
                                 <TextBlock Text="{x:Static vmp:Resources.StakeAllQuestion}" FontWeight="SemiBold" />
                                 <TextBlock

--- a/src/SIQuester/SIQuester/View/FlatDocView.xaml
+++ b/src/SIQuester/SIQuester/View/FlatDocView.xaml
@@ -69,7 +69,7 @@
         <DataTemplate x:Key="CompactQuestionView">
             <Border
                 Name="bd"
-                Background="#FFD5DDFF"
+                Background="{StaticResource SectionHeaderBrush}"
                 Margin="3"
                 Padding="4"
                 BorderThickness="0"
@@ -265,7 +265,7 @@
         <DataTemplate x:Key="QuestionView">
             <Border
                 Name="bd"
-                Background="#FFD5DDFF"
+                Background="{StaticResource SectionHeaderBrush}"
                 Margin="0,5,5,5"
                 Padding="6"
                 BorderThickness="0"
@@ -285,14 +285,14 @@
                                         Text="{Binding Key, Converter={StaticResource QuestionParameterNamesConverter}}"
                                         DockPanel.Dock="Left"
                                         FontWeight="Bold"
-                                        Foreground="Black"
+                                        Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                         Margin="0,2,10,2"
                                         TextWrapping="Wrap" />
 
                                     <ContentControl
                                         x:Name="value"
                                         Margin="0,2,0,0"
-                                        TextBlock.Foreground="Black"
+                                        TextBlock.Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                         Content="{Binding Value}"
                                         ContentTemplate="{Binding Value.Model.Type, Converter={StaticResource FlatParameterSelector}}" />
                                 </DockPanel>
@@ -354,7 +354,7 @@
         <DataTemplate x:Key="CompactThemeView">
             <Border
                 Name="bd"
-                Background="#FFD5DDFF"
+                Background="{StaticResource SectionHeaderBrush}"
                 Margin="3"
                 Padding="4"
                 BorderThickness="0"
@@ -417,7 +417,7 @@
         </Style>
 
         <DataTemplate x:Key="ThemeView">
-            <StackPanel Name="panel" Margin="0,6,6,0" Background="#FFA1C2DE" Width="240">
+            <StackPanel Name="panel" Margin="0,6,6,0" Background="{StaticResource SectionHeaderBrush}" Width="240">
                 <Border Name="border">
                     <TextBlock
                         Name="name"
@@ -507,7 +507,7 @@
 
         <DataTemplate x:Key="RoundView">
             <Border>
-                <StackPanel x:Name="bd" Margin="6" Background="#FFA1C2DE">
+                <StackPanel x:Name="bd" Margin="6" Background="{StaticResource SectionHeaderBrush}">
                     <TextBlock
                         Text="{Binding Model.Name}"
                         ToolTip="{Binding Model.Name}"
@@ -733,7 +733,7 @@
                     <TextBlock
                         Text="{Binding}"
                         FontWeight="Bold"
-                        Foreground="Black" />
+                        Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
                 </DataTemplate>
             </lc:TemplateConverter.DefaultTemplate>
 
@@ -744,7 +744,7 @@
                             DockPanel.Dock="Left"
                             Text="{Binding}"
                             FontWeight="Bold"
-                            Foreground="Black"
+                            Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                             Margin="0,3,0,0" />
 
                         <Button
@@ -1066,7 +1066,7 @@
                             <StackPanel x:Name="answerDurationSection" Orientation="Vertical" Margin="0,5,0,0" Visibility="Collapsed">
                                 <TextBlock
                                     Text="{x:Static lp:Resources.AnswerDuration}"
-                                    Foreground="Black"
+                                    Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                                     VerticalAlignment="Center" />
                                 
                                 <l:NumericTextBox
@@ -1074,8 +1074,8 @@
                                     Minimum="1"
                                     Maximum="120"
                                     Padding="2"
-                                    Background="White"
-                                    BorderBrush="Gray"
+                                    Background="{StaticResource WhiteBrush}"
+                                    BorderBrush="{StaticResource LightGrayBrush}"
                                     BorderThickness="1"
                                     Margin="0,5,0,0"
                                     HorizontalAlignment="Stretch" />
@@ -1396,7 +1396,7 @@
             VerticalOffset="-2"
             HorizontalOffset="20"
             util:PopupManager.Owner="{Binding Source={x:Static l:App.Current},Path=MainWindow}">
-            <Border Background="#FFF1F1F1" BorderBrush="Gray" BorderThickness="1" Opacity="0.8">
+            <Border Background="{StaticResource WhiteBrush}" BorderBrush="Gray" BorderThickness="1" Opacity="0.8">
                 <Border.Triggers>
                     <EventTrigger RoutedEvent="Border.MouseEnter">
                         <BeginStoryboard>

--- a/src/SIQuester/SIQuester/View/ImportTextView.xaml
+++ b/src/SIQuester/SIQuester/View/ImportTextView.xaml
@@ -182,7 +182,7 @@
                         <TextBox
                             TextWrapping="Wrap"
                             IsReadOnly="True"
-                            Background="LightGray"
+                            Background="{StaticResource LightGrayBrush}"
                             Padding="10"
                             Text="{Binding ImportText}"
                             ScrollViewer.VerticalScrollBarVisibility="Auto"
@@ -222,7 +222,7 @@
                             ScrollViewer.VerticalScrollBarVisibility="Auto"
                             IsReadOnly="True"
                             FontSize="14"
-                            Background="LightGray"
+                            Background="{StaticResource LightGrayBrush}"
                             Margin="10,10,10,0"
                             Padding="5"
                             lb:ScrollableBehavior.IsAttached="True">
@@ -250,7 +250,7 @@
                             </FlowDocument>
                         </RichTextBox>
 
-                        <TextBlock Grid.Column="1" Grid.Row="2" FontSize="16" TextWrapping="Wrap" Margin="15" Foreground="DarkRed">
+                        <TextBlock Grid.Column="1" Grid.Row="2" FontSize="16" TextWrapping="Wrap" Margin="15" Foreground="{StaticResource DarkRedTextBrush}">
                             <Run Text="{Binding Info}" /><Run Text=": " /><Run Text="{Binding Problem}" />
                         </TextBlock>
                         
@@ -342,7 +342,7 @@
                                                     <TextBlock
                                                         Text="{Binding}"
                                                         TextWrapping="Wrap"
-                                                        Background="#FFEEEEEE"
+                                                        Background="{StaticResource WhiteBrush}"
                                                         Padding="7"
                                                         HorizontalAlignment="Stretch" />
                                                 </DataTemplate>
@@ -417,7 +417,7 @@
                                 Padding="4"
                                 IsReadOnly="True"
                                 VerticalScrollBarVisibility="Auto"
-                                Background="LightPink" />
+                                Background="{StaticResource WrongAnswerBackgroundBrush}" />
 
                             <CheckBox
                                 Grid.Row="2"

--- a/src/SIQuester/SIQuester/View/PackagePreview.xaml
+++ b/src/SIQuester/SIQuester/View/PackagePreview.xaml
@@ -12,7 +12,8 @@
     d:DesignHeight="450"
     d:DesignWidth="1200"
     d:DataContext="{d:DesignInstance vm:PreviewViewModel}"
-    Background="White">
+    Background="{StaticResource WhiteBrush}"
+    Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
     <UserControl.Resources>
         <lc:ContentTypeConverter x:Key="ContentTypeConverter" />
     </UserControl.Resources>
@@ -32,7 +33,7 @@
             
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Margin="2" Background="Lavender" Padding="5,3">
+                    <TextBlock Margin="2" Background="{StaticResource LavenderBrush}" Padding="5,3">
                         <Run Text="{Binding Key, Mode=OneWay, Converter={StaticResource ContentTypeConverter}}" /><Run Text=" (" /><Run Text="{Binding Value, Mode=OneWay}" /><Run Text=")" />
                     </TextBlock>
                 </DataTemplate>
@@ -48,7 +49,7 @@
             
             <ItemsControl.ItemTemplate>
                 <DataTemplate>
-                    <TextBlock Text="{Binding}" Margin="2" Background="#DDDDDD" Padding="5,3" />
+                    <TextBlock Text="{Binding}" Margin="2" Background="{StaticResource LightGrayBrush}" Padding="5,3" />
                 </DataTemplate>
             </ItemsControl.ItemTemplate>
         </ItemsControl>
@@ -62,7 +63,7 @@
 
             <ItemsControl.ItemTemplate>
                 <DataTemplate DataType="p:Round">
-                    <StackPanel Margin="0,5,5,0" Background="LightBlue">
+                    <StackPanel Margin="0,5,5,0" Background="{StaticResource LightBlueBrush}">
                         <TextBlock Text="{Binding Name}" FontSize="25" FontWeight="Bold" Margin="10,6" />
 
                         <ItemsControl ItemsSource="{Binding Themes}" Margin="10,4" Width="400">

--- a/src/SIQuester/SIQuester/View/PointAnswerTemplate.xaml
+++ b/src/SIQuester/SIQuester/View/PointAnswerTemplate.xaml
@@ -32,7 +32,7 @@
             VerticalAlignment="Center"
             IsReadOnly="True" />
 
-        <TextBlock Text="&#x00B1;" VerticalAlignment="Center" Margin="0,0,2,0" Foreground="Black" />
+        <TextBlock Text="&#x00B1;" VerticalAlignment="Center" Margin="0,0,2,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
 
         <TextBox
             Text="{Binding Deviation, UpdateSourceTrigger=PropertyChanged}"
@@ -43,7 +43,7 @@
             HorizontalContentAlignment="Center"
             VerticalAlignment="Center"
             IsReadOnly="True"
-            Background="#F3F3F3" />
+            Background="{StaticResource WhiteBrush}" />
 
         <Button
             Command="{Binding SelectPoint}"

--- a/src/SIQuester/SIQuester/View/SelectTagsView.xaml
+++ b/src/SIQuester/SIQuester/View/SelectTagsView.xaml
@@ -33,9 +33,9 @@
                 
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <Border Margin="0,5,5,0" Background="Lavender" Padding="5,3,3,3">
+                        <Border Margin="0,5,5,0" Background="{StaticResource LavenderBrush}" Padding="5,3,3,3">
                             <StackPanel Orientation="Horizontal">
-                                <TextBlock Text="{Binding}" FontSize="18" Margin="0,0,0,5" />
+                                <TextBlock Text="{Binding}" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" FontSize="18" Margin="0,0,0,5" />
 
                                 <Button
                                     Command="{Binding DataContext.RemoveItem, RelativeSource={RelativeSource AncestorType=ItemsControl}}"
@@ -67,7 +67,7 @@
                     Padding="2,4,2,2"
                     FontSize="18"
                     BorderThickness="0"
-                    Background="Lavender" />
+                    Background="{StaticResource LavenderBrush}" />
 
                 <Button
                     Command="{Binding AddItem}"
@@ -134,7 +134,27 @@
                                             Cursor="Hand">
                                             <Button.Style>
                                                 <Style TargetType="Button">
+                                                    <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
+                                                    <Setter Property="Background" Value="{StaticResource SectionHeaderBrush}" />
+                                                    <Setter Property="Template">
+                                                        <Setter.Value>
+                                                            <ControlTemplate TargetType="Button">
+                                                                <Border
+                                                                    Background="{TemplateBinding Background}"
+                                                                    Padding="{TemplateBinding Padding}"
+                                                                    CornerRadius="7"
+                                                                    SnapsToDevicePixels="True"
+                                                                    TextBlock.Foreground="{TemplateBinding Foreground}">
+                                                                    <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                                                </Border>
+                                                            </ControlTemplate>
+                                                        </Setter.Value>
+                                                    </Setter>
                                                     <Style.Triggers>
+                                                        <Trigger Property="IsMouseOver" Value="True">
+                                                            <Setter Property="Background" Value="{StaticResource ActiveBrush}" />
+                                                        </Trigger>
+
                                                         <DataTrigger Value="True">
                                                             <DataTrigger.Binding>
                                                                 <MultiBinding Converter="{StaticResource ContainsConverter}">
@@ -143,7 +163,7 @@
                                                                 </MultiBinding>
                                                             </DataTrigger.Binding>
 
-                                                            <Setter Property="Background" Value="Lavender" />
+                                                            <Setter Property="Background" Value="{StaticResource LightBlueBrush}" />
                                                         </DataTrigger>
                                                     </Style.Triggers>
                                                 </Style>

--- a/src/SIQuester/SIQuester/View/SettingsView.xaml
+++ b/src/SIQuester/SIQuester/View/SettingsView.xaml
@@ -216,7 +216,7 @@
                     Margin="0,5,0,0"
                     Height="200"
                     IsReadOnly="True"
-                    Background="LightGray"
+                    Background="{StaticResource LightGrayBrush}"
                     TextWrapping="Wrap"
                     VerticalScrollBarVisibility="Auto" />
 

--- a/src/SIQuester/SIQuester/View/StatisticsView.xaml
+++ b/src/SIQuester/SIQuester/View/StatisticsView.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008" 
     xmlns:lvm="clr-namespace:SIQuester.ViewModel;assembly=SIQuester.ViewModel"
     xmlns:lp="clr-namespace:SIQuester.Properties"
+    xmlns:m="clr-namespace:SIQuester.Model;assembly=SIQuester.ViewModel"
     mc:Ignorable="d" 
     d:DesignHeight="300"
     d:DesignWidth="300"
@@ -16,17 +17,20 @@
         </Style>
     </UserControl.Resources>
     
-    <DockPanel Margin="5">
+    <DockPanel
+        Margin="5"
+        Background="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource ThemeBackgroundConverter}, FallbackValue=#FFFBFBFF, TargetNullValue=#FFFBFBFF}"
+        TextElement.Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
         <StackPanel Orientation="Vertical" DockPanel.Dock="Top">
-            <CheckBox IsChecked="{Binding CheckEmptyAuthors}">
+            <CheckBox IsChecked="{Binding CheckEmptyAuthors}" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                 <TextBlock Text="{x:Static lp:Resources.AuthorsAbsence}" />
             </CheckBox>
             
-            <CheckBox IsChecked="{Binding CheckEmptySources}" Margin="0,2,0,0">
+            <CheckBox IsChecked="{Binding CheckEmptySources}" Margin="0,2,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                 <TextBlock Text="{x:Static lp:Resources.SourcesAbsense}" />
             </CheckBox>
             
-            <CheckBox IsChecked="{Binding CheckBrackets}" Margin="0,2,0,0">
+            <CheckBox IsChecked="{Binding CheckBrackets}" Margin="0,2,0,0" Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}">
                 <TextBlock Text="{x:Static lp:Resources.OpenCloseBracketsIncosistency}" />
             </CheckBox>
 
@@ -52,7 +56,7 @@
                 <ItemsControl ItemsSource="{Binding Warnings}">
                     <ItemsControl.ItemTemplate>
                         <DataTemplate>
-                            <DockPanel Margin="0,5" Background="#EEEEEE">
+                            <DockPanel Margin="0,5" Background="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource ThemeBackgroundConverter}, FallbackValue=#FFFBFBFF, TargetNullValue=#FFFBFBFF}">
                                 <Button
                                     Command="{Binding NavigateToSource}"
                                     Style="{StaticResource {x:Static ToolBar.ButtonStyleKey}}"
@@ -64,13 +68,19 @@
                                     <Image Source="{StaticResource RightImageKey}" />
                                 </Button>
 
-                                <TextBlock Text="{Binding Title}" TextWrapping="Wrap" Margin="5" />
+                                <TextBlock
+                                    Text="{Binding Title}"
+                                    Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
+                                    TextWrapping="Wrap"
+                                    Margin="5" />
                             </DockPanel>
                         </DataTemplate>
                     </ItemsControl.ItemTemplate>
                 </ItemsControl>
 
                 <TextBox
+                    Background="{Binding Theme, Source={x:Static m:AppSettings.Default}, Converter={StaticResource ThemeBackgroundConverter}, FallbackValue=#FFFBFBFF, TargetNullValue=#FFFBFBFF}"
+                    Foreground="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}"
                     Padding="3,3,0,0"
                     Margin="0,5,0,0"
                     Text="{Binding Result}"

--- a/src/SIQuester/SIQuester/View/TextsStorageView.xaml
+++ b/src/SIQuester/SIQuester/View/TextsStorageView.xaml
@@ -13,7 +13,8 @@
     <UserControl.Resources>
         <Style x:Key="LightTextBox" TargetType="{x:Type TextBox}">
             <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Background" Value="White" />
+            <Setter Property="Background" Value="{StaticResource WhiteBrush}" />
+            <Setter Property="Foreground" Value="{DynamicResource {x:Static SystemColors.ControlTextBrushKey}}" />
             <Setter Property="TextWrapping" Value="Wrap" />
             <Setter Property="Height" Value="Auto" />
             <Setter Property="Margin" Value="0,2,0,0" />
@@ -87,7 +88,7 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
         
-        <StackPanel Orientation="Horizontal" Background="Lavender">
+        <StackPanel Orientation="Horizontal" Background="{StaticResource LavenderBrush}">
             <StackPanel.Resources>
                 <Style TargetType="{x:Type Button}" BasedOn="{StaticResource {x:Static ToolBar.ButtonStyleKey}}">
                     <Style.Triggers>
@@ -133,7 +134,7 @@
                     <Setter Property="Template">
                         <Setter.Value>
                             <ControlTemplate TargetType="ListBoxItem">
-                                <Border Name="bd" BorderThickness="1" Padding="8" Margin="5,5,0,0" Background="#FFD2DCFF">
+                                <Border Name="bd" BorderThickness="1" Padding="8" Margin="5,5,0,0" Background="{StaticResource SectionHeaderBrush}">
                                     <DockPanel>
                                         <Button
                                             Name="bDelete"


### PR DESCRIPTION
Поправлены некоторые места в тёмной теме, где не было видно текста, закрашены места, где ранее оставались части светлой темы.
Добавлена тёмно-серая тема отдельной опцией, которая на не-OLED матрицах выглядит более приятной для глаз.

https://github.com/user-attachments/assets/33a71eb1-c3e1-409b-b359-d3e7282599c6

