### PR TITLE
Счётчик заполненных вопросов

### DIFF
--- a/src/SIQuester/SIQuester.ViewModel/Helpers/QuestionExtensions.cs
+++ b/src/SIQuester/SIQuester.ViewModel/Helpers/QuestionExtensions.cs
@@ -1,0 +1,72 @@
+﻿using SIPackages;
+using SIPackages.Core;
+
+namespace SIQuester.ViewModel.Helpers;
+
+/// <summary>
+/// Provides helper functions for detecting filled question parts.
+/// </summary>
+internal static class QuestionExtensions
+{
+    /// <summary>
+    /// Detects whether the question has both content and a right answer filled in.
+    /// </summary>
+    /// <param name="question">Question to check.</param>
+    internal static bool IsFilled(this Question question) => HasContent(question) && question.HasAnswer();
+
+    /// <summary>
+    /// Detects whether the question right answer is filled in.
+    /// </summary>
+    /// <param name="question">Question to check.</param>
+    internal static bool HasAnswer(this Question question)
+    {
+        var answerType = question.Parameters.TryGetValue(QuestionParameterNames.AnswerType, out var answerTypeParameter)
+            ? answerTypeParameter.SimpleValue
+            : StepParameterValues.SetAnswerTypeType_Text;
+
+        return answerType switch
+        {
+            // The answer is validated by the client (e.g. an HTML minigame); there is nothing to fill in the package
+            StepParameterValues.SetAnswerTypeType_ManagedByClient => true,
+            // Every answer option must have content
+            StepParameterValues.SetAnswerTypeType_Select => HasFilledOptions(question),
+            // The position on the image must be set
+            StepParameterValues.SetAnswerTypeType_Point => HasSelectedPoint(question),
+            // Text and number answers are stored as plain right answers
+            _ => question.Right.Any(answer => !string.IsNullOrWhiteSpace(answer)),
+        };
+    }
+
+    /// <summary>
+    /// Detects whether the question body contains media.
+    /// </summary>
+    /// <param name="question">Question to check.</param>
+    /// <remarks>
+    /// Unlike <see cref="Question.HasMediaContent" />, the media of the other parameters
+    /// (the complex answer in the first place) is not taken into account.
+    /// </remarks>
+    internal static bool HasQuestionMedia(this Question question) =>
+        question.Parameters.TryGetValue(QuestionParameterNames.Question, out var body)
+        && body.ContentValue != null
+        && body.ContentValue.Any(item => item.Type != ContentTypes.Text);
+
+    // Only the question parameter counts as content (text or media); the complex answer parameter is ignored
+    private static bool HasContent(Question question) =>
+        question.Parameters.TryGetValue(QuestionParameterNames.Question, out var body)
+        && body.ContentValue != null
+        && body.ContentValue.Any(item => !string.IsNullOrWhiteSpace(item.Value));
+
+    private static bool HasFilledOptions(Question question) =>
+        question.Parameters.TryGetValue(QuestionParameterNames.AnswerOptions, out var options)
+        && options.GroupValue != null
+        && options.GroupValue.Count > 0
+        && options.GroupValue.Values.All(option =>
+            option.ContentValue != null
+            && option.ContentValue.Any(item => !string.IsNullOrWhiteSpace(item.Value)));
+
+    // Point answers store the position as "x,y,aspect"; the point is set only when all three parts are present
+    private static bool HasSelectedPoint(Question question) =>
+        question.Right.Count > 0
+        && question.Right[0].Split(',') is { Length: 3 } parts
+        && parts.All(part => !string.IsNullOrWhiteSpace(part));
+}

--- a/src/SIQuester/SIQuester.ViewModel/Workspaces/QDocument.cs
+++ b/src/SIQuester/SIQuester.ViewModel/Workspaces/QDocument.cs
@@ -63,6 +63,11 @@ public sealed class QDocument : WorkspaceViewModel
     private const string ChangesFileName = "changes.json";
 
     /// <summary>
+    /// Delay before the filled question count is recalculated.
+    /// </summary>
+    private static readonly TimeSpan FilledQuestionCountUpdateDelay = TimeSpan.FromMilliseconds(500);
+
+    /// <summary>
     /// Созданный объект
     /// </summary>
     public static object? ActivatedObject { get; set; }
@@ -1224,6 +1229,12 @@ public sealed class QDocument : WorkspaceViewModel
     private static int CountQuestionsInRound(RoundViewModel round) =>
         round.Themes.Sum(theme => theme.Questions.Count);
 
+    /// <summary>
+    /// Counts the questions that have both content and a right answer filled in.
+    /// </summary>
+    private int CountFilledQuestions() =>
+        Package.Rounds.Sum(round => round.Themes.Sum(theme => theme.Questions.Count(question => question.Model.IsFilled())));
+
     public StorageContextViewModel StorageContext { get; set; }
 
     private bool _isLinksClearingBlocked;
@@ -1365,9 +1376,34 @@ public sealed class QDocument : WorkspaceViewModel
             {
                 _questionCount = value;
                 OnPropertyChanged();
+                OnPropertyChanged(nameof(AllQuestionsFilled));
             }
         }
     }
+
+    private int _filledQuestionCount;
+
+    /// <summary>
+    /// Gets the number of questions that have both content and a right answer filled in.
+    /// </summary>
+    public int FilledQuestionCount
+    {
+        get => _filledQuestionCount;
+        private set
+        {
+            if (_filledQuestionCount != value)
+            {
+                _filledQuestionCount = value;
+                OnPropertyChanged();
+                OnPropertyChanged(nameof(AllQuestionsFilled));
+            }
+        }
+    }
+
+    /// <summary>
+    /// Gets whether every question in the document is filled.
+    /// </summary>
+    public bool AllQuestionsFilled => QuestionCount > 0 && FilledQuestionCount == QuestionCount;
 
     private readonly IPackageTemplatesRepository _packageTemplatesRepository;
     private readonly IDocumentViewModelFactory _documentViewModelFactory;
@@ -1473,11 +1509,49 @@ public sealed class QDocument : WorkspaceViewModel
 
         // Initialize question count after package is loaded and listeners are set up
         QuestionCount = CountTotalQuestions();
+        FilledQuestionCount = CountFilledQuestions();
     }
 
     private void OperationsManager_Error(Exception exc) => OnError(exc);
 
-    private void OperationsManager_Changed() => Changed = true; // TODO: delegate all change logic to OperationsManager
+    private void OperationsManager_Changed()
+    {
+        Changed = true; // TODO: delegate all change logic to OperationsManager
+        ScheduleFilledQuestionCountUpdate();
+    }
+
+    private bool _filledQuestionCountUpdateScheduled;
+
+    /// <summary>
+    /// Updates the filled question count after a delay merging the changes that happen during it.
+    /// </summary>
+    /// <remarks>
+    /// Recounting the whole package on each change would be too slow,
+    /// so the recount is delayed and performed only once for a series of changes.
+    /// </remarks>
+    private async void ScheduleFilledQuestionCountUpdate()
+    {
+        if (_filledQuestionCountUpdateScheduled)
+        {
+            return;
+        }
+
+        _filledQuestionCountUpdateScheduled = true;
+
+        try
+        {
+            await Task.Delay(FilledQuestionCountUpdateDelay);
+            FilledQuestionCount = CountFilledQuestions();
+        }
+        catch (Exception exc)
+        {
+            OnError(exc);
+        }
+        finally
+        {
+            _filledQuestionCountUpdateScheduled = false;
+        }
+    }
 
     private ICollection<string> FillFiles(MediaStorageViewModel mediaStorage, int maxFileSize, List<WarningViewModel> warnings)
     {
@@ -2281,14 +2355,14 @@ public sealed class QDocument : WorkspaceViewModel
 
                     var emptyQuestion = !emptyNormal
                         && (questionText == "" || questionText == Resources.Question)
-                        && !question.Model.HasMediaContent();
+                        && !question.Model.HasQuestionMedia();
 
                     if (emptyQuestion)
                     {
                         return $"{Resources.Round} {round.Model.Name}: {theme.Model.Name}, {question.Model.Price}: {Resources.ExportToSteamEmptyQuestion}";
                     }
 
-                    var noAnswer = !emptyNormal && (question.Right.Count == 0 || question.Right.Count == 1 && string.IsNullOrWhiteSpace(question.Right[0]));
+                    var noAnswer = !emptyNormal && !question.Model.HasAnswer();
 
                     if (noAnswer)
                     {

--- a/src/SIQuester/SIQuester.ViewModel/Workspaces/Sidebar/StatisticsViewModel.cs
+++ b/src/SIQuester/SIQuester.ViewModel/Workspaces/Sidebar/StatisticsViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using SIPackages;
 using SIPackages.Core;
+using SIQuester.ViewModel.Helpers;
 using SIQuester.ViewModel.Properties;
 using SIQuester.ViewModel.Workspaces.Sidebar;
 using System.Text;
@@ -186,11 +187,9 @@ public sealed class StatisticsViewModel : WorkspaceViewModel
                     
                     var emptyQuestion = !emptyNormal
                         && (questionText == "" || questionText == Resources.Question)
-                        && !question.Model.HasMediaContent();
+                        && !question.Model.HasQuestionMedia();
 
-                    var noAnswer = !emptyNormal
-                        && (question.Right.Count == 0 || question.Right.Count == 1 && string.IsNullOrWhiteSpace(question.Right[0]))
-                        && !question.IsManagedByClient;
+                    var noAnswer = !emptyNormal && !question.Model.HasAnswer();
 
                     var emptySources = question.Info.Sources.Count == 0 && _checkEmptySources;
 

--- a/src/SIQuester/SIQuester/Properties/Resources.Designer.cs
+++ b/src/SIQuester/SIQuester/Properties/Resources.Designer.cs
@@ -1115,6 +1115,24 @@ namespace SIQuester.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Filled:.
+        /// </summary>
+        public static string DocumentFilledLabel {
+            get {
+                return ResourceManager.GetString("DocumentFilledLabel", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Filled questions / total questions.
+        /// </summary>
+        public static string DocumentFilledQuestionCount {
+            get {
+                return ResourceManager.GetString("DocumentFilledQuestionCount", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Document font.
         /// </summary>
         public static string DocumentFont {

--- a/src/SIQuester/SIQuester/Properties/Resources.resx
+++ b/src/SIQuester/SIQuester/Properties/Resources.resx
@@ -1410,6 +1410,12 @@ When there are some questions in theme, they will be used as examples</value>
   <data name="DocumentQuestionCount" xml:space="preserve">
     <value>Total questions</value>
   </data>
+  <data name="DocumentFilledQuestionCount" xml:space="preserve">
+    <value>Filled questions / total questions</value>
+  </data>
+  <data name="DocumentFilledLabel" xml:space="preserve">
+    <value>Filled:</value>
+  </data>
   <data name="Format" xml:space="preserve">
     <value>Format</value>
   </data>

--- a/src/SIQuester/SIQuester/Properties/Resources.ru-RU.resx
+++ b/src/SIQuester/SIQuester/Properties/Resources.ru-RU.resx
@@ -1406,6 +1406,12 @@
   <data name="DocumentQuestionCount" xml:space="preserve">
     <value>Всего вопросов</value>
   </data>
+  <data name="DocumentFilledQuestionCount" xml:space="preserve">
+    <value>Заполнено вопросов / всего вопросов</value>
+  </data>
+  <data name="DocumentFilledLabel" xml:space="preserve">
+    <value>Заполнено:</value>
+  </data>
   <data name="Format" xml:space="preserve">
     <value>Формат</value>
   </data>

--- a/src/SIQuester/SIQuester/View/DocumentView.xaml
+++ b/src/SIQuester/SIQuester/View/DocumentView.xaml
@@ -416,13 +416,31 @@
                 </StackPanel.Resources>
 
                 <TextBlock
-                    Text="{Binding QuestionCount}"
                     FontSize="14"
                     FontWeight="SemiBold"
                     Foreground="#FF555555"
                     VerticalAlignment="Center"
                     Margin="0,0,10,0"
-                    ToolTip="{x:Static lp:Resources.DocumentQuestionCount}" />
+                    ToolTip="{x:Static lp:Resources.DocumentFilledQuestionCount}">
+                    <Run Text="{x:Static lp:Resources.DocumentFilledLabel}" />
+                    <Run Text="{Binding FilledQuestionCount, Mode=OneWay}">
+                        <Run.Style>
+                            <Style TargetType="Run">
+                                <Setter Property="Foreground" Value="#FF4A90D9" />
+                                <Style.Triggers>
+                                    <DataTrigger Binding="{Binding AllQuestionsFilled}" Value="True">
+                                        <Setter Property="Foreground" Value="#FF3E9C42" />
+                                    </DataTrigger>
+                                </Style.Triggers>
+                            </Style>
+                        </Run.Style>
+                    </Run>
+                    <Run Text=" / " />
+                    <Run
+                        Text="{Binding QuestionCount, Mode=OneWay}"
+                        Foreground="#FF3E9C42"
+                        ToolTip="{x:Static lp:Resources.DocumentQuestionCount}" />
+                </TextBlock>
 
                 <ToggleButton
                     Name="helpToggle"


### PR DESCRIPTION
Считает количество заполненных вопросов/общее количество вопросов в пакете. Заполненным считается любой вопрос, у которого заполнены блок вопроса и блок ответа.
Также исправлён подсчёт ответов для типов вопросов «Точка на изображении», «Выбор из вариантов» и «HTML мини-игра». Раньше при выборе типа вопроса «Точка на изображении» или «Выбор из вариантов» в левой панели не отображалось предупреждение об отсутствии ответа, даже если точка не была выбрана или варианты не были заполнены. Также для «HTML мини-игры» ответ нельзя заполнить в SIQuester, но в левой панели всё равно отображалось предупреждение об отсутствии текста ответа.


https://github.com/user-attachments/assets/ed543326-263b-4be3-85ac-6529cbc70e7c

