### PR TITLE
Show media duration in SIQuester player

### DIFF
--- a/src/SIQuester/SIQuester/App.xaml
+++ b/src/SIQuester/SIQuester/App.xaml
@@ -1067,6 +1067,11 @@
                 <Setter Property="Margin" Value="20,0,0,0" />
             </Style>
 
+            <Style x:Key="playTime" TargetType="TextBlock">
+                <Setter Property="Margin" Value="10,0,0,0" />
+                <Setter Property="VerticalAlignment" Value="Center" />
+            </Style>
+
             <!-- FullTreeView start -->
 
             <Style x:Key="PackageStyle" BasedOn="{StaticResource QTreeViewItem}" TargetType="{x:Type TreeViewItem}">
@@ -2838,6 +2843,7 @@
                             <StackPanel Orientation="Horizontal" VerticalAlignment="Center" Margin="4" ToolTip="{Binding Model.Value}">
                                 <ToggleButton Style="{StaticResource playButton}" Name="play" />
                                 <Slider Style="{StaticResource playSlider}" Name="progress" />
+                                <TextBlock Style="{StaticResource playTime}" Name="time" />
 
                                 <MediaElement
                                     Name="mediaElement1"
@@ -2846,7 +2852,8 @@
                                     UnloadedBehavior="Manual"
                                     ScrubbingEnabled="{Binding RelativeSource={RelativeSource Self}, Path=HasVideo}"
                                     lb:MediaController.PlayPauseButton="{Binding ElementName=play}"
-                                    lb:MediaController.Progress="{Binding ElementName=progress}" />
+                                    lb:MediaController.Progress="{Binding ElementName=progress}"
+                                    lb:MediaController.Time="{Binding ElementName=time}" />
                             </StackPanel>
                         </DataTemplate>
                     </Setter.Value>
@@ -2899,11 +2906,13 @@
                                     Height="200"
                                     ScrubbingEnabled="{Binding RelativeSource={RelativeSource Self}, Path=HasVideo}"
                                     lb:MediaController.PlayPauseButton="{Binding ElementName=play}"
-                                    lb:MediaController.Progress="{Binding ElementName=progress}" />
+                                    lb:MediaController.Progress="{Binding ElementName=progress}"
+                                    lb:MediaController.Time="{Binding ElementName=time}" />
 
                                 <StackPanel Orientation="Horizontal" Grid.Row="1" Margin="0,5,0,0">
                                     <ToggleButton Style="{StaticResource playButton}" Name="play" />
                                     <Slider Style="{StaticResource playSlider}" Name="progress" />
+                                    <TextBlock Style="{StaticResource playTime}" Name="time" />
                                 </StackPanel>
                             </Grid>
                         </DataTemplate>

--- a/src/SIQuester/SIQuester/Behaviors/MediaController.cs
+++ b/src/SIQuester/SIQuester/Behaviors/MediaController.cs
@@ -51,6 +51,7 @@ public static class MediaController
             if (media.NaturalDuration.HasTimeSpan)
             {
                 media.Position = TimeSpan.FromSeconds(media.NaturalDuration.TimeSpan.TotalSeconds * slider.Value / 100);
+                UpdateTime(media);
             }
         };
 
@@ -71,6 +72,8 @@ public static class MediaController
                     {
                         blocked = false;
                     }
+
+                    UpdateTime(media);
                 }
             });
         };
@@ -79,6 +82,8 @@ public static class MediaController
         {
             if (media.NaturalDuration.HasTimeSpan)
             {
+                UpdateTime(media);
+
                 try
                 {
                     timer.Start();
@@ -99,6 +104,13 @@ public static class MediaController
 
         media.Unloaded += ended;
     }
+
+    public static TextBlock GetTime(DependencyObject obj) => (TextBlock)obj.GetValue(TimeProperty);
+
+    public static void SetTime(DependencyObject obj, TextBlock value) => obj.SetValue(TimeProperty, value);
+
+    public static readonly DependencyProperty TimeProperty =
+        DependencyProperty.RegisterAttached("Time", typeof(TextBlock), typeof(MediaController), new PropertyMetadata(null));
 
     public static ToggleButton GetPlayPauseButton(DependencyObject obj) => (ToggleButton)obj.GetValue(PlayPauseButtonProperty);
 
@@ -222,6 +234,21 @@ public static class MediaController
 
     public static readonly DependencyProperty IsPlayingProperty =
         DependencyProperty.RegisterAttached("IsPlaying", typeof(bool), typeof(MediaController), new PropertyMetadata(false));
+
+    private static void UpdateTime(MediaElement media)
+    {
+        var time = GetTime(media);
+
+        if (time == null)
+        {
+            return;
+        }
+
+        time.Text = $"{FormatTime(media.Position)} / {FormatTime(media.NaturalDuration.TimeSpan)}";
+    }
+
+    private static string FormatTime(TimeSpan time) =>
+        time.TotalHours >= 1.0 ? time.ToString(@"h\:mm\:ss") : time.ToString(@"m\:ss");
 
     private static void StopPreviousMedia(MediaElement mediaElement, ToggleButton playPauseButton)
     {

--- a/src/SIQuester/SIQuester/View/MediaStorageView.xaml
+++ b/src/SIQuester/SIQuester/View/MediaStorageView.xaml
@@ -49,9 +49,11 @@
                             LoadedBehavior="Manual"
                             UnloadedBehavior="Manual"
                             lb:MediaController.PlayPauseButton="{Binding ElementName=play}"
-                            lb:MediaController.Progress="{Binding ElementName=progress}" />
+                            lb:MediaController.Progress="{Binding ElementName=progress}"
+                            lb:MediaController.Time="{Binding ElementName=time}" />
 
                         <ToggleButton Style="{StaticResource playButton}" Name="play" DockPanel.Dock="Left" />
+                        <TextBlock Style="{StaticResource playTime}" Name="time" DockPanel.Dock="Right" />
                         <Slider Style="{StaticResource playSlider}" Name="progress" Width="Auto" VerticalAlignment="Center" />
                     </DockPanel>
                 </DataTemplate>
@@ -68,17 +70,19 @@
                         <Grid.ColumnDefinitions>
                             <ColumnDefinition Width="Auto" />
                             <ColumnDefinition />
+                            <ColumnDefinition Width="Auto" />
                         </Grid.ColumnDefinitions>
 
                         <MediaElement
-                            Grid.ColumnSpan="2"
+                            Grid.ColumnSpan="3"
                             Name="mediaElement1"
                             lb:MediaController.Source="{Binding}"
                             LoadedBehavior="Manual"
                             UnloadedBehavior="Manual"
                             ScrubbingEnabled="True"
                             lb:MediaController.PlayPauseButton="{Binding ElementName=play}"
-                            lb:MediaController.Progress="{Binding ElementName=progress}" />
+                            lb:MediaController.Progress="{Binding ElementName=progress}"
+                            lb:MediaController.Time="{Binding ElementName=time}" />
 
                         <ToggleButton Style="{StaticResource playButton}" Name="play" Grid.Row="1" Margin="0,10,0,0" />
 
@@ -90,6 +94,8 @@
                             Grid.Column="1"
                             Margin="20,10,0,0"
                             VerticalAlignment="Center" />
+
+                        <TextBlock Style="{StaticResource playTime}" Name="time" Grid.Row="1" Grid.Column="2" Margin="10,10,0,0" />
                     </Grid>
                 </DataTemplate>
             </ls:AtomTypeSelector.VideoTemplate>


### PR DESCRIPTION
Displays current position and total duration next to the player progress bar: `0:14 / 3:47` (`1:02:30` for media longer than an hour).

Covers all four live players — audio and video content items in the question editor (`AudioControlNewStyle` and `VideoControlNewStyle` in `App.xaml`) and both players in the media storage panel (`MediaStorageView.xaml`).

### Implementation

A new `MediaController.Time` attached property receives the `TextBlock` to fill in, following the existing `Progress` and `PlayPauseButton` properties. No extra timer is introduced: the text is refreshed by the progress timer that already ticks once per second, and additionally on seek, so the value does not lag behind the slider while dragging.

### Note

The duration appears once playback starts. `MediaElement.Source` is assigned lazily on the first play, so the natural duration is not known before that — reading it earlier would require extracting every visible media file from the package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)